### PR TITLE
Fix Resource#set when passing 2 arguments

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -1255,21 +1255,20 @@ Resource.prototype.set = function (attributes) {
     var value = arguments[1];
     attributes = {};
     attributes[key] = value;
-  } else {
+  }
 
-    /**
-     * @event set
-     * @memberof module:mio.Resource.on
-     * @param {Resource} resource
-     * @param {Object} attributes
-     */
-    this.constructor.emit('set', this, attributes);
-    this.emit('set', attributes);
+  /**
+   * @event set
+   * @memberof module:mio.Resource.on
+   * @param {Resource} resource
+   * @param {Object} attributes
+   */
+  this.constructor.emit('set', this, attributes);
+  this.emit('set', attributes);
 
-    for (var attr in attributes) {
-      if (this.constructor.attributes[attr]) {
-        this[attr] = attributes[attr];
-      }
+  for (var attr in attributes) {
+    if (this.constructor.attributes[attr]) {
+      this[attr] = attributes[attr];
     }
   }
 

--- a/test/mio.js
+++ b/test/mio.js
@@ -1190,6 +1190,15 @@ describe('Resource', function() {
       expect(model).to.not.have.property('age');
     });
 
+    it('sets value using (key, value) for defined attributes', function() {
+      var Resource = mio.Resource.extend()
+        .attr('id', { primary: true })
+        .attr('name');
+      var model = Resource.create().set('name', 'joeb');
+      expect(model.name).to.equal('joeb');
+      expect(model).to.not.have.property('age');
+    });
+
     it('emits "setting" event', function(done) {
       var Resource = mio.Resource.extend()
         .attr('id', { primary: true })


### PR DESCRIPTION
Passing 2 arguments was a no-op on the resource. The fix was to move the code in the else block outside so that the logic for setting is actually executed.